### PR TITLE
Add PostgreSQL support

### DIFF
--- a/PlainSql.Migrations.Tests/AbstractMigratorTests.cs
+++ b/PlainSql.Migrations.Tests/AbstractMigratorTests.cs
@@ -83,7 +83,9 @@ GO";
                     tx.Commit();
                 }
 
-                Assert.NotEmpty(c.Query<string>("SELECT Filename FROM [Migrations]"));
+                var select = c.IsPostgre() ? "SELECT Filename FROM Migrations" : "SELECT Filename FROM [Migrations]"; 
+
+                Assert.NotEmpty(c.Query<string>(select));
             });
         }
 
@@ -92,14 +94,18 @@ GO";
         {
             Connection.WithCleanDbConnection((c) =>
             {
+                var defaultScript = "CREATE TABLE [bla]([Id] [uniqueidentifier] NOT NULL)";
+                var postgreScript = "CREATE TABLE bla (Id varchar(1) NOT NULL)";
                 var migration = new MigrationScript
                 {
                     Name = "create bla table",
-                    Script = "CREATE TABLE [bla]([Id] [uniqueidentifier] NOT NULL)"
+                    Script = c.IsPostgre() ? postgreScript : defaultScript
                 };
                 Migrator.ExecuteMigrations(c, new[] { migration }, true);
 
-                Assert.Empty(c.Query<object>("SELECT * FROM [bla]"));
+                var select = c.IsPostgre() ? "SELECT * FROM bla" : "SELECT * FROM [bla]"; 
+
+                Assert.Empty(c.Query<object>(select));
             });
         }
 
@@ -108,17 +114,20 @@ GO";
         {
             Connection.WithCleanDbConnection((c) =>
             {
+                var defaultScript = "CREATE TABLE [bla]([Id] [uniqueidentifier] NOT NULL)";
+                var postgreScript = "CREATE TABLE bla (Id varchar(1) NOT NULL)";
                 var migration = new MigrationScript
                 {
                     Name = "create bla table",
-                    Script = "CREATE TABLE [bla]([Id] [uniqueidentifier] NOT NULL)"
+                    Script = c.IsPostgre() ? postgreScript : defaultScript
                 };
                 Migrator.ExecuteMigrations(c, new[] { migration }, true);
 
                 Migrator.ExecuteMigrations(c, new[] { migration }, true);
-
+                
+                var select = c.IsPostgre() ? "SELECT Filename FROM Migrations" : "SELECT Filename FROM [Migrations]"; 
                 // Migrations table + bla
-                Assert.Equal(2, c.Query<string>("SELECT Filename FROM [Migrations]").ToList().Count);
+                Assert.Equal(2, c.Query<string>(select).ToList().Count);
             });
         }
 

--- a/PlainSql.Migrations.Tests/AbstractMigratorTests.cs
+++ b/PlainSql.Migrations.Tests/AbstractMigratorTests.cs
@@ -83,9 +83,7 @@ GO";
                     tx.Commit();
                 }
 
-                var select = c.IsPostgre() ? "SELECT Filename FROM Migrations" : "SELECT Filename FROM [Migrations]"; 
-
-                Assert.NotEmpty(c.Query<string>(select));
+                Assert.NotEmpty(c.Query<string>("SELECT Filename FROM Migrations"));
             });
         }
 
@@ -94,18 +92,14 @@ GO";
         {
             Connection.WithCleanDbConnection((c) =>
             {
-                var defaultScript = "CREATE TABLE [bla]([Id] [uniqueidentifier] NOT NULL)";
-                var postgreScript = "CREATE TABLE bla (Id varchar(1) NOT NULL)";
                 var migration = new MigrationScript
                 {
                     Name = "create bla table",
-                    Script = c.IsPostgre() ? postgreScript : defaultScript
+                    Script = "CREATE TABLE bla (Id varchar(1) NOT NULL)"
                 };
                 Migrator.ExecuteMigrations(c, new[] { migration }, true);
 
-                var select = c.IsPostgre() ? "SELECT * FROM bla" : "SELECT * FROM [bla]"; 
-
-                Assert.Empty(c.Query<object>(select));
+                Assert.Empty(c.Query<object>("SELECT * FROM bla"));
             });
         }
 
@@ -114,20 +108,17 @@ GO";
         {
             Connection.WithCleanDbConnection((c) =>
             {
-                var defaultScript = "CREATE TABLE [bla]([Id] [uniqueidentifier] NOT NULL)";
-                var postgreScript = "CREATE TABLE bla (Id varchar(1) NOT NULL)";
                 var migration = new MigrationScript
                 {
                     Name = "create bla table",
-                    Script = c.IsPostgre() ? postgreScript : defaultScript
+                    Script = "CREATE TABLE bla (Id varchar(1) NOT NULL)"
                 };
                 Migrator.ExecuteMigrations(c, new[] { migration }, true);
 
                 Migrator.ExecuteMigrations(c, new[] { migration }, true);
-                
-                var select = c.IsPostgre() ? "SELECT Filename FROM Migrations" : "SELECT Filename FROM [Migrations]"; 
+
                 // Migrations table + bla
-                Assert.Equal(2, c.Query<string>(select).ToList().Count);
+                Assert.Equal(2, c.Query<string>("SELECT Filename FROM Migrations").ToList().Count);
             });
         }
 

--- a/PlainSql.Migrations.Tests/IDbConnectionExtensions.cs
+++ b/PlainSql.Migrations.Tests/IDbConnectionExtensions.cs
@@ -17,8 +17,8 @@ namespace PlainSql.Migrations.Tests
             {
                 using (var tx = c.BeginTransaction())
                 {
-                    c.Execute(c.IsPostgre() ? "DROP TABLE IF EXISTS bla" : "DROP TABLE IF EXISTS [bla]", transaction: tx);
-                    c.Execute(c.IsPostgre() ? "DROP TABLE IF EXISTS Migrations" : "DROP TABLE IF EXISTS [Migrations]", transaction: tx);
+                    c.Execute("DROP TABLE IF EXISTS bla", transaction: tx);
+                    c.Execute("DROP TABLE IF EXISTS Migrations", transaction: tx);
 
                     tx.Commit();
                 }

--- a/PlainSql.Migrations.Tests/IDbConnectionExtensions.cs
+++ b/PlainSql.Migrations.Tests/IDbConnectionExtensions.cs
@@ -17,8 +17,8 @@ namespace PlainSql.Migrations.Tests
             {
                 using (var tx = c.BeginTransaction())
                 {
-                    c.Execute("DROP TABLE IF EXISTS [bla]", transaction: tx);
-                    c.Execute("DROP TABLE IF EXISTS [Migrations]", transaction: tx);
+                    c.Execute(c.IsPostgre() ? "DROP TABLE IF EXISTS bla" : "DROP TABLE IF EXISTS [bla]", transaction: tx);
+                    c.Execute(c.IsPostgre() ? "DROP TABLE IF EXISTS Migrations" : "DROP TABLE IF EXISTS [Migrations]", transaction: tx);
 
                     tx.Commit();
                 }

--- a/PlainSql.Migrations.Tests/MsSqlMigratorTests.cs
+++ b/PlainSql.Migrations.Tests/MsSqlMigratorTests.cs
@@ -1,12 +1,6 @@
-using Dapper;
-using Dapper.Contrib.Extensions;
 using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.SqlClient;
-using System.Linq;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace PlainSql.Migrations.Tests
 {
@@ -27,11 +21,11 @@ namespace PlainSql.Migrations.Tests
 
         protected string GetConnectionString()
         {
-            var connectinStringFromEnvironment = Environment.GetEnvironmentVariable("PLAIN_SQL_MIGRATIONS_MS_SQL");
+            var connectionStringFromEnvironment = Environment.GetEnvironmentVariable("PLAIN_SQL_MIGRATIONS_MS_SQL");
 
-            if (!String.IsNullOrWhiteSpace(connectinStringFromEnvironment))
+            if (!String.IsNullOrWhiteSpace(connectionStringFromEnvironment))
             {
-                return connectinStringFromEnvironment;
+                return connectionStringFromEnvironment;
             }
 
             var IsAppVeyor = Environment.GetEnvironmentVariable("Appveyor")?.ToUpperInvariant() == "TRUE";

--- a/PlainSql.Migrations.Tests/PlainSql.Migrations.Tests.csproj
+++ b/PlainSql.Migrations.Tests/PlainSql.Migrations.Tests.csproj
@@ -13,6 +13,7 @@
     </PackageReference>
     <PackageReference Include="Dapper.Contrib" Version="1.50.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Npgsql" Version="4.1.2" />
     <PackageReference Include="PrettierTestLogger" Version="1.1.1" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.109.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
+++ b/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Data;
+using Npgsql;
+
+namespace PlainSql.Migrations.Tests
+{
+    public class PostgreMigratorTest : AbstractMigratorTests
+    {
+        protected override IDbConnection Connection
+        {
+            get
+            {
+                var connectionString = GetConnectionString();
+
+                var c = new NpgsqlConnection(connectionString);
+                c.Open();
+
+                return c;
+            }
+        }
+
+        protected string GetConnectionString()
+        {
+            var connectionStringFromEnvironment = Environment.GetEnvironmentVariable("PLAIN_SQL_MIGRATIONS_POSTGRE_SQL");
+
+            if (!String.IsNullOrWhiteSpace(connectionStringFromEnvironment))
+            {
+                return connectionStringFromEnvironment;
+            }
+
+            return "Server=127.0.0.1;User Id=postgres;Password=postgres";
+        }
+    }
+}

--- a/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
+++ b/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
@@ -28,6 +28,13 @@ namespace PlainSql.Migrations.Tests
                 return connectionStringFromEnvironment;
             }
 
+            var IsAppVeyor = Environment.GetEnvironmentVariable("Appveyor")?.ToUpperInvariant() == "TRUE";
+
+            if (IsAppVeyor)
+            {
+                return @"Server=127.0.0.1;User Id=postgres;Password=Password12!";
+            }
+
             return "Server=127.0.0.1;User Id=postgres;Password=postgres";
         }
     }

--- a/PlainSql.Migrations.Tests/SqliteMigratorTests.cs
+++ b/PlainSql.Migrations.Tests/SqliteMigratorTests.cs
@@ -1,5 +1,4 @@
 using Dapper;
-using Dapper.Contrib.Extensions;
 using PlainSql.Migrations.Sqlite;
 using System.Collections.Generic;
 using System.Data;

--- a/PlainSql.Migrations/DbConnectionExtensions.cs
+++ b/PlainSql.Migrations/DbConnectionExtensions.cs
@@ -9,5 +9,10 @@ namespace PlainSql.Migrations
         {
             return connection.GetType().AssemblyQualifiedName.IndexOf("SQLite", StringComparison.InvariantCultureIgnoreCase) >= 0;
         }
+        
+        public static bool IsPostgre(this IDbConnection connection)
+        {
+            return connection.GetType().AssemblyQualifiedName.IndexOf("Npgsql", StringComparison.InvariantCultureIgnoreCase) >= 0;
+        }
     }
 }

--- a/PlainSql.Migrations/DbConnectionExtensions.cs
+++ b/PlainSql.Migrations/DbConnectionExtensions.cs
@@ -9,7 +9,7 @@ namespace PlainSql.Migrations
         {
             return connection.GetType().AssemblyQualifiedName.IndexOf("SQLite", StringComparison.InvariantCultureIgnoreCase) >= 0;
         }
-        
+
         public static bool IsPostgre(this IDbConnection connection)
         {
             return connection.GetType().AssemblyQualifiedName.IndexOf("Npgsql", StringComparison.InvariantCultureIgnoreCase) >= 0;

--- a/PlainSql.Migrations/Migrator.cs
+++ b/PlainSql.Migrations/Migrator.cs
@@ -114,14 +114,14 @@ namespace PlainSql.Migrations
   [AppliedOn] [datetimeoffset](7) NOT NULL,
   CONSTRAINT PK_Migrations PRIMARY KEY (Id)
 )";
-        
+
         private const string CreateTableScriptPostgre = @"CREATE TABLE Migrations (
   Id char(36) NOT NULL,
   Filename varchar(255) NOT NULL,
   AppliedOn timestamp NOT NULL,
   CONSTRAINT PK_Migrations PRIMARY KEY (Id)
 )";
-        
+
         public static void CreateMigrationsTable(IDbConnection connection, IDbTransaction transaction)
         {
             var migrationTableMigration = new MigrationScript

--- a/PlainSql.Migrations/Migrator.cs
+++ b/PlainSql.Migrations/Migrator.cs
@@ -40,6 +40,11 @@ namespace PlainSql.Migrations
                     containsMigrationTable = connection.ExecuteScalar<int>("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='Migrations'",
                         transaction: transaction) == 1;
                 }
+                else if (connection.IsPostgre())
+                {
+                    containsMigrationTable = connection.ExecuteScalar<int>("SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='public' AND tablename='migrations'",
+                                                 transaction: transaction) == 1;
+                }
                 else
                 {
                     containsMigrationTable = connection.ExecuteScalar<int>("SELECT COUNT(*) FROM INFORMATION_SCHEMA.tables WHERE TABLE_SCHEMA='dbo' AND TABLE_NAME='Migrations'",
@@ -109,12 +114,20 @@ namespace PlainSql.Migrations
   [AppliedOn] [datetimeoffset](7) NOT NULL,
   CONSTRAINT PK_Migrations PRIMARY KEY (Id)
 )";
+        
+        private const string CreateTableScriptPostgre = @"CREATE TABLE Migrations (
+  Id char(36) NOT NULL,
+  Filename varchar(255) NOT NULL,
+  AppliedOn timestamp NOT NULL,
+  CONSTRAINT PK_Migrations PRIMARY KEY (Id)
+)";
+        
         public static void CreateMigrationsTable(IDbConnection connection, IDbTransaction transaction)
         {
             var migrationTableMigration = new MigrationScript
             {
                 Name = "Migration-Table",
-                Script = CreateTableScript
+                Script = connection.IsPostgre() ? CreateTableScriptPostgre : CreateTableScript
             };
 
             ExecuteMigration(connection, transaction, migrationTableMigration);

--- a/PlainSql.Migrations/PlainSql.Migrations.csproj
+++ b/PlainSql.Migrations/PlainSql.Migrations.csproj
@@ -17,6 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ private void ExecuteMigrations(string connectionString, string environment)
 
 * SQLite
 * MS SQL
+* PostgreSQL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 image: Visual Studio 2017
-services: mssql2016
+services:
+  - mssql2016
+  - postgresql
 branches:
   only:
   - master


### PR DESCRIPTION
This PR adds PostgreSQL support.

One aspect that's not very nice at the moment is that most literal SQL scripts (creating the migration table, tests) are doubled since [PostgreSQL does not support square bracket notation](https://stackoverflow.com/questions/37965562/square-bracket-in-table-column-name-is-not-supported). Any feedback on this issue is appreciated.