### PR TITLE
Feature/parallel migrations

### DIFF
--- a/PlainSql.Migrations.Tests/AbstractMigratorTests.cs
+++ b/PlainSql.Migrations.Tests/AbstractMigratorTests.cs
@@ -122,6 +122,34 @@ GO";
             });
         }
 
+        [Fact]
+        public async Task Can_execute_scripts_in_parallel()
+        {
+            Connection.CleanDbConnection();
+            Migrator.CreateMigrationsTable(Connection, null);
+
+            var result =
+                await Task.WhenAll(
+                    Task.Factory.StartNew(ExecuteMigration),
+                    Task.Factory.StartNew(ExecuteMigration),
+                    Task.Factory.StartNew(ExecuteMigration));
+
+            // Migrations table + bla
+            Assert.Equal(2, Connection.Query<string>("SELECT Filename FROM Migrations").ToList().Count);
+
+            bool ExecuteMigration()
+            {
+                var migration = new MigrationScript
+                {
+                    Name = "create bla table",
+                    Script = "CREATE TABLE bla (Id varchar(1) NOT NULL)"
+                };
+                using (var c = Connection)
+                    Migrator.ExecuteMigrations(c, new[] {migration}, false);
+                return true;
+            }
+        }
+
         private string RemoveEmptyLines(string x)
         {
             return String.Join("\r\n",

--- a/PlainSql.Migrations.Tests/AbstractMigratorTests.cs
+++ b/PlainSql.Migrations.Tests/AbstractMigratorTests.cs
@@ -122,11 +122,10 @@ GO";
             });
         }
 
-        [Fact]
-        public async Task Can_execute_scripts_in_parallel()
+        public static async Task ExecuteMigrationsInParallel(Func<IDbConnection> connection)
         {
-            Connection.CleanDbConnection();
-            Migrator.CreateMigrationsTable(Connection, null);
+            connection().CleanDbConnection();
+            Migrator.CreateMigrationsTable(connection(), null);
 
             var result =
                 await Task.WhenAll(
@@ -135,7 +134,7 @@ GO";
                     Task.Factory.StartNew(ExecuteMigration));
 
             // Migrations table + bla
-            Assert.Equal(2, Connection.Query<string>("SELECT Filename FROM Migrations").ToList().Count);
+            Assert.Equal(2, connection().Query<string>("SELECT Filename FROM Migrations").ToList().Count);
 
             bool ExecuteMigration()
             {
@@ -144,7 +143,7 @@ GO";
                     Name = "create bla table",
                     Script = "CREATE TABLE bla (Id varchar(1) NOT NULL)"
                 };
-                using (var c = Connection)
+                using (var c = connection())
                     Migrator.ExecuteMigrations(c, new[] {migration}, false);
                 return true;
             }

--- a/PlainSql.Migrations.Tests/IDbConnectionExtensions.cs
+++ b/PlainSql.Migrations.Tests/IDbConnectionExtensions.cs
@@ -11,17 +11,22 @@ namespace PlainSql.Migrations.Tests
 {
     public static class IDbConnectionExtensions
     {
+        public static void CleanDbConnection(this IDbConnection connection)
+        {
+            using (var tx = connection.BeginTransaction())
+            {
+                connection.Execute("DROP TABLE IF EXISTS bla", transaction: tx);
+                connection.Execute("DROP TABLE IF EXISTS Migrations", transaction: tx);
+
+                tx.Commit();
+            }
+        }
+
         public static void WithCleanDbConnection(this IDbConnection connection, Action<IDbConnection> action)
         {
             using (var c = connection)
             {
-                using (var tx = c.BeginTransaction())
-                {
-                    c.Execute("DROP TABLE IF EXISTS bla", transaction: tx);
-                    c.Execute("DROP TABLE IF EXISTS Migrations", transaction: tx);
-
-                    tx.Commit();
-                }
+                c.CleanDbConnection();
 
                 action(c);
             }

--- a/PlainSql.Migrations.Tests/MsSqlMigratorTests.cs
+++ b/PlainSql.Migrations.Tests/MsSqlMigratorTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Data;
 using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace PlainSql.Migrations.Tests
 {
@@ -36,6 +38,12 @@ namespace PlainSql.Migrations.Tests
             }
 
             return "Data Source=localhost;Initial Catalog=PlainSqlMigrations;User id=SA;Password=test123!;";
+        }
+
+        [Fact]
+        public Task Can_execute_scripts_in_parallel()
+        {
+            return ExecuteMigrationsInParallel(() => Connection);
         }
     }
 }

--- a/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
+++ b/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Data;
-using System.Linq;
 using System.Threading.Tasks;
 using Npgsql;
 using Xunit;

--- a/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
+++ b/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using Dapper;
 using Npgsql;
+using Xunit;
 
 namespace PlainSql.Migrations.Tests
 {

--- a/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
+++ b/PlainSql.Migrations.Tests/PostgreMigratorTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
-using Dapper;
 using Npgsql;
 using Xunit;
 
@@ -40,6 +39,12 @@ namespace PlainSql.Migrations.Tests
             }
 
             return "Server=127.0.0.1;User Id=postgres;Password=postgres";
+        }
+
+        [Fact]
+        public Task Can_execute_scripts_in_parallel()
+        {
+            return ExecuteMigrationsInParallel(() => Connection);
         }
     }
 }

--- a/PlainSql.Migrations/Migrator.cs
+++ b/PlainSql.Migrations/Migrator.cs
@@ -50,22 +50,7 @@ namespace PlainSql.Migrations
                     Console.WriteLine("Retrying execution of migrationscripts"+e);
                     retryCount--;
                 }
-                catch (DbException e) when (CouldBePostgresDeadlock(e) && retryCount != 0)
-                {
-                    Log.Information(e,"Retrying exection of migrationscripts");
-                    Console.WriteLine("Retrying execution of migrationscripts"+e);
-                    retryCount--;
-                }
             }
-        }
-
-        private static bool CouldBePostgresDeadlock(DbException e)
-        {
-            // var errorCodes = new[] {"42P07", "23505"};
-            var errorCodes = new string[0] ;
-            return string.Equals(e.Source, "npgsql", StringComparison.OrdinalIgnoreCase)
-                   && e.Data.Contains("SqlState")
-                   && errorCodes.Contains(e.Data["SqlState"]?.ToString());
         }
 
         private static void TryExecute(IDbConnection connection, IEnumerable<MigrationScript> migrationScripts, MigrationOptions options)

--- a/PlainSql.Migrations/Migrator.cs
+++ b/PlainSql.Migrations/Migrator.cs
@@ -14,14 +14,12 @@ namespace PlainSql.Migrations
     public static class Migrator
     {
         // TODO: Add a script hash to migrations to avoid scripts to be changed without running the migration
-        public static void ExecuteMigrations(this IDbConnection connection, IEnumerable<MigrationScript> migrationScripts,
-            bool createMigrationsTable = true)
+        public static void ExecuteMigrations(this IDbConnection connection, IEnumerable<MigrationScript> migrationScripts, bool createMigrationsTable = true)
         {
             ExecuteMigrations(connection, migrationScripts, options => { });
         }
 
-        public static void ExecuteMigrations(this IDbConnection connection, IEnumerable<MigrationScript> migrationScripts,
-            Action<MigrationOptionsBuilder> configure)
+        public static void ExecuteMigrations(this IDbConnection connection, IEnumerable<MigrationScript> migrationScripts, Action<MigrationOptionsBuilder> configure)
         {
             var builder = new MigrationOptionsBuilder().CreateMigrationsTable(true);
 
@@ -32,8 +30,7 @@ namespace PlainSql.Migrations
             ExecuteMigrations(connection, migrationScripts, options);
         }
 
-        public static void ExecuteMigrations(this IDbConnection connection, IEnumerable<MigrationScript> migrationScripts,
-            MigrationOptions options)
+        public static void ExecuteMigrations(this IDbConnection connection, IEnumerable<MigrationScript> migrationScripts, MigrationOptions options)
         {
             var retryCount = 3;
             while (retryCount > 0)
@@ -95,8 +92,7 @@ namespace PlainSql.Migrations
 
                 Log.Information("Executing {MigrationScriptsCount} migration scripts...", migrationScriptsToExecute.Count());
 
-                foreach (var migrationScript in migrationScriptsToExecute.Select(ProcessMigrationScript(connection,
-                    options.ScriptProcessors)))
+                foreach (var migrationScript in migrationScriptsToExecute.Select(ProcessMigrationScript(connection, options.ScriptProcessors)))
                 {
                     ExecuteMigration(connection, transaction, migrationScript);
                 }
@@ -105,8 +101,7 @@ namespace PlainSql.Migrations
             }
         }
 
-        private static Func<MigrationScript, MigrationScript> ProcessMigrationScript(IDbConnection connection,
-            IEnumerable<IMigrationScriptProcessor> processors)
+        private static Func<MigrationScript, MigrationScript> ProcessMigrationScript(IDbConnection connection, IEnumerable<IMigrationScriptProcessor> processors)
         {
             return (migrationScript) =>
             {
@@ -128,8 +123,7 @@ namespace PlainSql.Migrations
         {
             var statements = SplitIntoStatements(migrationScript.Script).ToList();
 
-            Log.Information("Executing {StatementsCount} statements in migration script {MigrationScriptName}...", statements.Count,
-                migrationScript.Name);
+            Log.Information("Executing {StatementsCount} statements in migration script {MigrationScriptName}...", statements.Count, migrationScript.Name);
 
             statements.ForEach(s => connection.Execute(s, transaction: transaction));
 

--- a/PlainSql.Migrations/Migrator.cs
+++ b/PlainSql.Migrations/Migrator.cs
@@ -46,8 +46,7 @@ namespace PlainSql.Migrations
                 // a sql exception that a deadlock
                 catch (SqlException e) when (e.Number == 1205 && retryCount != 0)
                 {
-                    Log.Information(e,"Retrying execution of migrationscripts");
-                    Console.WriteLine("Retrying execution of migrationscripts"+e);
+                    Log.Information(e,"{RetryCount} remaining retries for execution of migrations", retryCount);
                     retryCount--;
                 }
             }
@@ -90,7 +89,6 @@ namespace PlainSql.Migrations
 
                 var migrationsExecuted = connection.Query<string>(selectExecutedMigrations, transaction: transaction).ToList();
 
-                Console.Out.WriteLine("Migrations: " + migrationsExecuted.Count);
                 var migrationScriptsToExecute = migrationScripts
                     .Where(migrationScript => !migrationsExecuted.Contains(migrationScript.Name, StringComparer.OrdinalIgnoreCase))
                     .ToList();
@@ -104,11 +102,6 @@ namespace PlainSql.Migrations
                 }
 
                 transaction.Commit();
-                
-                // if (connection.IsPostgre())
-                // {
-                //     connection.Execute("select pg_advisory_unlock(1)", transaction: transaction);
-                // }
             }
         }
 


### PR DESCRIPTION
Using just `IsolationLevel.Serializiable` is not sufficient when running migrations in parallel.

- For Postgres the simplest solution seems to be using and [advisory transaction lock](https://vladmihalcea.com/how-do-postgresql-advisory-locks-work/).
- For SqlServer using `Serializable` is [dangerous](https://wiki.postgresql.org/wiki/Transactional_DDL_in_PostgreSQL:_A_Competitive_Analysis#SQL_Server)  with regards to executed statements in the migration scripts
 Using `with (SERIALIZABLE)` and a retry mechanism worked in a stable way
- Not sure if parallel migrations is relevant with SqlLite 