### PR TITLE
Add support for dotnet global tool

### DIFF
--- a/PlainSql.Migrations.Tool/PlainSql.Migrations.Tool.csproj
+++ b/PlainSql.Migrations.Tool/PlainSql.Migrations.Tool.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <ToolCommandName>migrate</ToolCommandName>
+    <Description>A .NET Global tool that executes PlainSql.Migrations</Description>
+    <PackageTags>sql;migrations;conventional;commit;git</PackageTags>
+    <Company>Softwarepark</Company>
+    <Authors>Jonathan Channon</Authors>
+    <PackageProjectUrl>https://github.com/Softwarepark/PlainSql.Migrations</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Softwarepark/PlainSql.Migrations</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
+    <PackageReference Include="Npgsql" Version="4.1.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PlainSql.Migrations\PlainSql.Migrations.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PlainSql.Migrations.Tool/Program.cs
+++ b/PlainSql.Migrations.Tool/Program.cs
@@ -55,7 +55,7 @@ namespace PlainSql.Migrations.Tool
                 connection.Open();
                 var migrationScripts = MigrationScriptsLoader.FromDirectory(MigrationScriptFolder);
                 Migrator.ExecuteMigrations(connection, migrationScripts, CreateMigrationsTable);
-
+                connection.Close();
                 Log.Information("Finished executing database migrations!");
             }
             catch (Exception e)

--- a/PlainSql.Migrations.Tool/Program.cs
+++ b/PlainSql.Migrations.Tool/Program.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Data;
+using System.Data.SqlClient;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Data.Sqlite;
+using Npgsql;
+using Serilog;
+
+namespace PlainSql.Migrations.Tool
+{
+    class Program
+    {
+        public static int Main(string[] args) => CommandLineApplication.Execute<Program>(args);
+
+        [Required]
+        [Option(Description = "The connection string", ShortName = "c", LongName = "connectionstring")]
+        public string ConnectionString { get; }
+
+        [Option(Description = "The folder where the migration scripts are located", ShortName = "m", LongName = "migrationscriptfolder")]
+        public string MigrationScriptFolder { get; set; } = "./MigrationScripts";
+
+        [Required]
+        [AllowedValues("mssql", "postgres", "sqllite", IgnoreCase = true)]
+        [Option(Description = "The database type to connect to", ShortName = "d", LongName = "databasetype")]
+        public string DatabaseType { get; set; }
+
+        [Option(Description = "Should migrations be logged in a migrations table", ShortName = "t", LongName = "createmigrationstable")]
+        public bool CreateMigrationsTable { get; set; } = true;
+
+        private void OnExecute()
+        {
+            //TODO Should we validate the scripts folder path
+            Log.Logger = new LoggerConfiguration()
+                .WriteTo.Console()
+                .CreateLogger();
+
+            Log.Information("Executing database migrations in {MigrationScriptFolder} using {ConnectionString}", MigrationScriptFolder, ConnectionString);
+            try
+            {
+                IDbConnection connection = null;
+                switch (DatabaseType)
+                {
+                    case "mssql":
+                        connection = new SqlConnection(ConnectionString);
+                        break;
+                    case "postgres":
+                        connection = new NpgsqlConnection(ConnectionString);
+                        break;
+                    case "sqllite":
+                        connection = new SqliteConnection(ConnectionString);
+                        break;
+                }
+
+                connection.Open();
+                var migrationScripts = MigrationScriptsLoader.FromDirectory(MigrationScriptFolder);
+                Migrator.ExecuteMigrations(connection, migrationScripts, CreateMigrationsTable);
+
+                Log.Information("Finished executing database migrations!");
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "There has been a problem executing the migrations:");
+            }
+        }
+    }
+}

--- a/PlainSql.Migrations.sln
+++ b/PlainSql.Migrations.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlainSql.Migrations", "Plai
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlainSql.Migrations.Tests", "PlainSql.Migrations.Tests\PlainSql.Migrations.Tests.csproj", "{5371A94E-7C80-4F0F-A46B-A3D9BD9567CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlainSql.Migrations.Tool", "PlainSql.Migrations.Tool\PlainSql.Migrations.Tool.csproj", "{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,5 +46,17 @@ Global
 		{5371A94E-7C80-4F0F-A46B-A3D9BD9567CB}.Release|x64.Build.0 = Release|Any CPU
 		{5371A94E-7C80-4F0F-A46B-A3D9BD9567CB}.Release|x86.ActiveCfg = Release|Any CPU
 		{5371A94E-7C80-4F0F-A46B-A3D9BD9567CB}.Release|x86.Build.0 = Release|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Debug|x64.Build.0 = Debug|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Debug|x86.Build.0 = Debug|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Release|x64.ActiveCfg = Release|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Release|x64.Build.0 = Release|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Release|x86.ActiveCfg = Release|Any CPU
+		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ private void ExecuteMigrations(string connectionString, string environment)
 `MigrationScriptsLoader.FromDirectory` orders the migration scripts alphabetically
 (using `System.StringComparer.InvariantCulture`).
 
+## Global Tool
+
+`PlainSql.Migrations` offers a .NET Global tool that can be installed like so `dotnet tool install --global PlainSql.Migrations.Tool` and then executed from the terminal like so `migrate -c "Uid=myuser;Pwd=password1;Host=localhost;Database=northwind;" -d postgres`. 
+
 ## Database Support
 
 * SQLite


### PR DESCRIPTION
This allows people to run migrations from the terminal. See README for info. The output looks like:

![Screenshot 2020-07-08 at 08 48 15](https://user-images.githubusercontent.com/105126/86893290-4d084a00-c0f9-11ea-94b9-4c9f81fad060.png)

I'm not sure how we publish PlainSql.Migrations but we will need a separate step to publish this tool as `PlainSql.Migrations.Tool`