### PR TITLE
bump System.Data.SqlClient dependency

### DIFF
--- a/PlainSql.Migrations.Tool/PlainSql.Migrations.Tool.csproj
+++ b/PlainSql.Migrations.Tool/PlainSql.Migrations.Tool.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="3.1.5" />
     <PackageReference Include="Npgsql" Version="6.0.4" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PlainSql.Migrations/PlainSql.Migrations.csproj
+++ b/PlainSql.Migrations/PlainSql.Migrations.csproj
@@ -21,5 +21,8 @@
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <!-- This is a transitive dependency. We explicitly include it to avoid auto-resolving
+	 a version with a vulnerability -->
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 </Project>

--- a/PlainSql.Migrations/PlainSql.Migrations.csproj
+++ b/PlainSql.Migrations/PlainSql.Migrations.csproj
@@ -18,11 +18,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-
-  <ItemGroup>
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
The `System.Data.SqlClient` dependency has a vulnerability in version <= 4.8.4. This PR bumps the dependency version for this reason.