### PR TITLE
Migration generator

### DIFF
--- a/PlainSql.Migrations.Generator/PlainSql.Migrations.Generator.csproj
+++ b/PlainSql.Migrations.Generator/PlainSql.Migrations.Generator.csproj
@@ -24,5 +24,8 @@
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>
-
+  
+  <ItemGroup>
+    <ProjectReference Include="..\PlainSql.Migrations\PlainSql.Migrations.csproj" />
+  </ItemGroup>
 </Project>

--- a/PlainSql.Migrations.Generator/PlainSql.Migrations.Generator.csproj
+++ b/PlainSql.Migrations.Generator/PlainSql.Migrations.Generator.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Version>1.0</Version>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PackAsTool>true</PackAsTool>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <ToolCommandName>generate-migration</ToolCommandName>
+    <Description>A .NET Global tool that generates timestamped PlainSql.Migration files</Description>
+    <PackageTags>sql;migrations;conventional;commit;git</PackageTags>
+    <Company>Trustbit</Company>
+    <Authors>Felix Auer</Authors>
+    <PackageProjectUrl>https://github.com/trustbit/PlainSql.Migrations</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/trustbit/PlainSql.Migrations</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/PlainSql.Migrations.Generator/PlainSql.Migrations.Generator.csproj
+++ b/PlainSql.Migrations.Generator/PlainSql.Migrations.Generator.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Version>1.0</Version>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackAsTool>true</PackAsTool>
     <PackageOutputPath>./nupkg</PackageOutputPath>
@@ -20,12 +20,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2"/>
+    <PackageReference Include="Serilog" Version="2.12.0"/>
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0"/>
   </ItemGroup>
-  
+
   <ItemGroup>
-    <ProjectReference Include="..\PlainSql.Migrations\PlainSql.Migrations.csproj" />
+    <ProjectReference Include="..\PlainSql.Migrations\PlainSql.Migrations.csproj"/>
   </ItemGroup>
 </Project>

--- a/PlainSql.Migrations.Generator/Program.cs
+++ b/PlainSql.Migrations.Generator/Program.cs
@@ -67,7 +67,7 @@ class Program
     private string CreateFilename()
     {
         var titleCaseDescription = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(Description);
-        var filename = DateTime.Now.ToString("yyyyMMddHHmmss") + "_" +
+        var filename = DateTime.UtcNow.ToString("yyyyMMddHHmmss") + "_" +
                        Regex.Replace(titleCaseDescription, @"\s+", "") + ".sql";
         return filename;
     }

--- a/PlainSql.Migrations.Generator/Program.cs
+++ b/PlainSql.Migrations.Generator/Program.cs
@@ -1,0 +1,74 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using McMaster.Extensions.CommandLineUtils;
+using Serilog;
+
+namespace PlainSql.Migrations.Generator;
+
+class Program
+{
+    public static int Main(string[] args) => CommandLineApplication.Execute<Program>(args);
+
+    private const string Placeholder = "SELECT * FROM Students WHERE Name = 'Robert'); DROP TABLE Students;--";
+
+    [Required]
+    [Argument(0)]
+    private string Description { get; }
+
+    [Option(Description = "The folder where the migration scripts are located",
+        ShortName = "m",
+        LongName = "migrationscriptfolder")]
+    private string MigrationScriptFolder { get; set; } = "./MigrationScripts";
+
+    private void OnExecute()
+    {
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console()
+            .CreateLogger();
+
+        try
+        {
+            CheckIfMigrationScriptFolderExists();
+
+            var filename = CreateFilename();
+
+            Log.Information("Creating migration file {filename} in {MigrationScriptFolder}",
+                filename,
+                MigrationScriptFolder);
+
+            CreateMigrationFile(filename);
+
+            Log.Information("Sucessfully created {filename}!", filename);
+        }
+        catch (Exception e)
+        {
+            Log.Error("There has been a problem creating the migration file: " + e.Message);
+        }
+    }
+
+    private void CreateMigrationFile(string filename)
+    {
+        using var fs = File.Create(MigrationScriptFolder + "/" + filename);
+        var info = new UTF8Encoding(true).GetBytes(Placeholder);
+        fs.Write(info, 0, info.Length);
+    }
+
+    private void CheckIfMigrationScriptFolderExists()
+    {
+        if (!Directory.Exists(MigrationScriptFolder))
+        {
+            throw new InvalidOperationException(
+                $"Error while loading migration scripts. Directory '{MigrationScriptFolder}' does not exist");
+        }
+    }
+
+    private string CreateFilename()
+    {
+        var titleCaseDescription = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(Description);
+        var filename = DateTime.Now.ToString("yyyyMMddHHmmss") + "_" +
+                       Regex.Replace(titleCaseDescription, @"\s+", "") + ".sql";
+        return filename;
+    }
+}

--- a/PlainSql.Migrations.Generator/Program.cs
+++ b/PlainSql.Migrations.Generator/Program.cs
@@ -44,7 +44,7 @@ class Program
         }
         catch (Exception e)
         {
-            Log.Error("There has been a problem creating the migration file: " + e.Message);
+            Log.Error(e, "There has been a problem creating the migration file: " + e.Message);
         }
     }
 

--- a/PlainSql.Migrations.sln
+++ b/PlainSql.Migrations.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlainSql.Migrations.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlainSql.Migrations.Tool", "PlainSql.Migrations.Tool\PlainSql.Migrations.Tool.csproj", "{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlainSql.Migrations.Generator", "PlainSql.Migrations.Generator\PlainSql.Migrations.Generator.csproj", "{6A45F0FE-262C-467E-A47B-2FFEC1E02553}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,5 +60,17 @@ Global
 		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Release|x64.Build.0 = Release|Any CPU
 		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Release|x86.ActiveCfg = Release|Any CPU
 		{BB78F3B9-73E4-42C6-B0AD-F09BE6604A12}.Release|x86.Build.0 = Release|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Debug|x64.Build.0 = Debug|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Debug|x86.Build.0 = Debug|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Release|x64.ActiveCfg = Release|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Release|x64.Build.0 = Release|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Release|x86.ActiveCfg = Release|Any CPU
+		{6A45F0FE-262C-467E-A47B-2FFEC1E02553}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -39,7 +39,36 @@ private void ExecuteMigrations(string connectionString, string environment)
 
 ## Global Tool
 
-`PlainSql.Migrations` offers a .NET Global tool that can be installed like so `dotnet tool install --global PlainSql.Migrations.Tool` and then executed from the terminal like so `migrate -c "Uid=myuser;Pwd=password1;Host=localhost;Database=northwind;" -d postgres`. 
+`PlainSql.Migrations` offers a .NET Global tool that can be installed like
+so `dotnet tool install --global PlainSql.Migrations.Tool` and then executed from the terminal like
+so `migrate -c "Uid=myuser;Pwd=password1;Host=localhost;Database=northwind;" -d postgres`.
+
+## Creating Migration Files
+
+`PlainSql.Migrations` also includes a .NET Global tool to generate timestamped migration files in the format
+of `yyyyMMddHHmmss_DescriptionOfTheMigration.sql`. 
+
+### Usage
+
+#### Installation
+
+Install with `dotnet tool install --global PlainSql.Migrations.Generator`.
+
+#### Generating Files
+Use the `generate-migration` command.
+
+```
+$ generate-migration "add phone number to user table"
+[10:42:21 INF] Creating migration file 20230302104221_AddPhoneNumberToUserTable.sql in ./MigrationScripts
+[10:42:21 INF] Sucessfully created 20230302104221_AddPhoneNumberToUserTable.sql!
+```
+
+A different location for the migration scripts folder can be supplied with the `-m` option:
+```
+$ generate-migration "add phone number to user table" -m "./migrations"
+[10:44:54 INF] Creating migration file 20230302104454_AddPhoneNumberToUserTable.sql in ./migrations
+[10:44:54 INF] Sucessfully created 20230302104454_AddPhoneNumberToUserTable.sql!
+```
 
 ## Database Support
 


### PR DESCRIPTION
Added a tool that lets users generate timestamped migration files to reduce conflicts when working with version control.

Example:

![image](https://user-images.githubusercontent.com/5065153/222637085-032c6f71-a8c4-47b0-805c-d92316fe041b.png)

More information can be found in the README.md